### PR TITLE
Added typings for embed SDK functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.0.0
+
+### Added
+
+- Typings for new Bento embed SDK functions
+  - `getEventMetadataForAccount`
+  - `getEventMetadataForAccountUser`
+
+### Removed
+
+- Remove deprecated `identify()` typings
 
 ### Fixed
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { BentoSDK } from "./sdk";
+
 export type BentoInstance = {
   /**
    * Whether Bento is initialized.
@@ -25,6 +27,10 @@ export type BentoInstance = {
    * Tip: You can always re-initialize Bento later.
    */
   reset(): Promise<boolean>;
+  /**
+   * Contains utility/helper SDK functions to access and work with Bento data.
+   */
+  sdk: BentoSDK;
 };
 
 export type DynamicAttributes = {
@@ -32,7 +38,13 @@ export type DynamicAttributes = {
    * You may also add any additional attributes you want associated with this account/accountUser within Bento,
    * for example what products they bought, their pricing tier, or user role.
    */
-  [attributeName: string]: string | Date | number | boolean | string[] | undefined;
+  [attributeName: string]:
+    | string
+    | Date
+    | number
+    | boolean
+    | string[]
+    | undefined;
 };
 
 export type BentoSettings = {
@@ -138,6 +150,8 @@ export type OnGuideLoadEvent = CustomEvent<{
 export type SidebarOpenEvent = CustomEvent<undefined>;
 export type SidebarCloseEvent = CustomEvent<undefined>;
 export type OnFormFactorEmbedLoad = CustomEvent<undefined>;
+
+export * from "./sdk";
 
 declare global {
   interface Window {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,6 @@ export type BentoInstance = {
    */
   initialized: boolean;
   /**
-   * Currently, this is the same as calling `initialize`.
-   *
-   * @deprecated use `initialize` instead. This will be removed on June 1, 2023 */
-  identify(bentoSettings?: BentoSettings): Promise<boolean>;
-  /**
    * Tell Bento to initialize.
    *
    * Please make sure you've set the `window.bentoSettings` object before.

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,29 @@
+export type GetEventMetadataOptions = { eventName: string };
+export type GetEventMetadataResult = {
+  firstSeenAt: string;
+  lastSeenAt: string;
+} | null;
+
+export interface BentoSDK {
+  /**
+   * Retrieve Bento metadata for the given event pertaining to the currently-identified account.
+   *
+   * Metadata will include information such as when the event was first/last received.
+   *
+   * If the event has not been received by Bento, this function will return `null`.
+   */
+  getEventMetadataForAccount(
+    options: GetEventMetadataOptions
+  ): Promise<GetEventMetadataResult>;
+
+  /**
+   * Retrieve Bento metadata for the given event pertaining to the currently-identified account-user.
+   *
+   * Metadata will include information such as when the event was first/last received.
+   *
+   * If the event has not been received by Bento, this function will return `null`.
+   */
+  getEventMetadataForAccountUser(
+    options: GetEventMetadataOptions
+  ): Promise<GetEventMetadataResult>;
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2,6 +2,7 @@ export type GetEventMetadataOptions = { eventName: string };
 export type GetEventMetadataResult = {
   firstSeenAt: string;
   lastSeenAt: string;
+  receivedCount: number;
 } | null;
 
 export interface BentoSDK {


### PR DESCRIPTION
This PR:

- Introduces typings for the new SDK functions in the embed, specifically for retrieving account/user event metadata.
- Removes typings for the now-deprecated `identify()` function.