### PR TITLE
Adds `bento-loaded` window event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentoapp/types",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Common types used by Bento JavaScript SDKs",
   "author": "Bento",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,8 @@ export type BentoSettings = {
 //
 
 export enum BentoWindowEvents {
+  /** Fired when Bento script has finished loading and is ready to be called */
+  loaded = "bento-loaded",
   /** Fired when Bento has been initialized */
   initialized = "bento-initialized",
 }
@@ -124,6 +126,7 @@ export enum BentoDocumentEvents {
   onComponentVisibilityChange = "bento-onComponentVisibilityChange",
 }
 
+export type LoadedEvent = CustomEvent<undefined>;
 export type InitializedEvent = CustomEvent<undefined>;
 export type ButtonClickedEvent = CustomEvent<{
   /** Either the event message or name */
@@ -167,6 +170,7 @@ declare global {
   }
 
   interface WindowEventMap {
+    [BentoWindowEvents.loaded]: LoadedEvent;
     [BentoWindowEvents.initialized]: InitializedEvent;
   }
 


### PR DESCRIPTION
Simply document the new window event that is going to be triggered as soon as the Bento script finishes loading and is ready for taking calls.