### PR TITLE
Remove source maps from build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0
+
+### Removed
+
+- Removed invalid source maps from compiled output
+
 ## 1.4.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentoapp/types",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Common types used by Bento JavaScript SDKs",
   "author": "Bento",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentoapp/types",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "Common types used by Bento JavaScript SDKs",
   "author": "Bento",
   "license": "MIT",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "declarationMap": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true
   }
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "emitDeclarationOnly": false,
     "outDir": "build/types"
   }


### PR DESCRIPTION
This PR removes the source maps from the build output.

We currently include source maps, but we don't include the original source files meaning the maps point to invalid references.